### PR TITLE
Add setting for using default break also in timer

### DIFF
--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -38,6 +38,7 @@ import "../config.js" as DB
 
 Page {
     id: root
+
     function resetDatabase(){
         //console.log(hours);
         DB.resetDatabase();
@@ -141,6 +142,7 @@ Page {
             breakTimerRunning = false;
         }
         breakDuration = getBreakTimerDuration();
+
         var dateNow = new Date();
         var endSelectedHour = dateNow.getHours();
         var endSelectedMinute = dateNow.getMinutes();
@@ -148,6 +150,14 @@ Page {
         if (endSelectedHour < startSelectedHour)
             endHour +=24
         duration = ((((endHour - startSelectedHour)*60) + (endSelectedMinute - startSelectedMinute)) / 60).toFixed(2)
+
+        // Add default break duration if settings allow and no break recorded
+        // Also only add it if it is less than the duration
+        var defaultDur = settings.getDefaultBreakDuration()
+        if (!breakDuration && settings.getDefaultBreakInTimer() && defaultDur < duration) {
+            breakDuration = defaultDur
+        }
+
         if(!fromCover) {
             pageStack.push(Qt.resolvedUrl("Add.qml"), {
                                   dataContainer: root,

--- a/qml/pages/Settings.qml
+++ b/qml/pages/Settings.qml
@@ -205,7 +205,7 @@ Page {
                         settings.setEndTimeStaysFixed("no")
                 }
             }
-            SectionHeader { text: qsTr("Startup options") }
+            SectionHeader { text: qsTr("Timer options") }
             TextSwitch {
                 id: autoStartSwitch
                 checked: false
@@ -217,6 +217,19 @@ Page {
                         settings.setTimerAutoStart(true)
                     else
                         settings.setTimerAutoStart(false)
+                }
+            }
+            TextSwitch {
+                id: defaultBreakInTimerSwitch
+                checked: false
+                text: qsTr("Add break when using timer")
+                description: qsTr("Default break is not added automatically when using timer.")
+                onCheckedChanged: {
+                    defaultBreakInTimerSwitch.description = checked ? qsTr("Default break is added automatically when using timer. Only added when break is not recorded with the break timer.") : qsTr("Default break is not added automatically when using timer.")
+                    if(checked)
+                        settings.setDefaultBreakInTimer(true)
+                    else
+                        settings.setDefaultBreakInTimer(false)
                 }
             }
             SectionHeader { text: qsTr("Set currency") }
@@ -703,6 +716,8 @@ Page {
             autoStartSwitch.checked = true
         else if(timerAutoStart === false)
             autoStartSwitch.checked = false
+
+        defaultBreakInTimerSwitch.checked = settings.getDefaultBreakInTimer()
 
         currencyTextArea.text = settings.getCurrencyString();
         toTextArea.text = settings.getToAddress();

--- a/qml/pages/Settings.qml
+++ b/qml/pages/Settings.qml
@@ -221,7 +221,7 @@ Page {
             }
             TextSwitch {
                 id: defaultBreakInTimerSwitch
-                checked: false
+                checked: true
                 text: qsTr("Add break when using timer")
                 description: qsTr("Default break is not added automatically when using timer.")
                 onCheckedChanged: {

--- a/src/SettingsClass.cpp
+++ b/src/SettingsClass.cpp
@@ -139,7 +139,7 @@ bool Settings::getDefaultBreakInTimer()
 {
     QSettings s("harbour-workinghourstracker", "harbour-workinghourstracker");
     s.beginGroup("Settings");
-    defaultBreakInTimer = s.value("defaultBreakInTimer").toBool();
+    defaultBreakInTimer = s.value("defaultBreakInTimer", true).toBool();
     s.endGroup();
     return defaultBreakInTimer;
 }

--- a/src/SettingsClass.cpp
+++ b/src/SettingsClass.cpp
@@ -135,6 +135,22 @@ void Settings::setTimerAutoStart(bool value) {
     s.endGroup();
 }
 
+bool Settings::getDefaultBreakInTimer()
+{
+    QSettings s("harbour-workinghourstracker", "harbour-workinghourstracker");
+    s.beginGroup("Settings");
+    defaultBreakInTimer = s.value("defaultBreakInTimer").toBool();
+    s.endGroup();
+    return defaultBreakInTimer;
+}
+
+void Settings::setDefaultBreakInTimer(bool value) {
+    QSettings s("harbour-workinghourstracker", "harbour-workinghourstracker");
+    s.beginGroup("Settings");
+    s.setValue("defaultBreakInTimer", value);
+    s.endGroup();
+}
+
 QString Settings::getDefaultProjecId() {
     QSettings s("harbour-workinghourstracker", "harbour-workinghourstracker");
     s.beginGroup("Settings");

--- a/src/SettingsClass.h
+++ b/src/SettingsClass.h
@@ -60,6 +60,9 @@ public:
     Q_INVOKABLE bool getTimerAutoStart();
     Q_INVOKABLE void setTimerAutoStart(bool value);
 
+    Q_INVOKABLE bool getDefaultBreakInTimer();
+    Q_INVOKABLE void setDefaultBreakInTimer(bool value);
+
     Q_INVOKABLE QString getDefaultProjecId();
     Q_INVOKABLE void setDefaultProjecId(QString value);
 
@@ -81,6 +84,7 @@ private:
     QString endsNowByDefault;
     QString endTimeStaysFixed;
     bool timerAutoStart;
+    bool defaultBreakInTimer;
     QString defaultProjectId;
     QString currencyString;
     QString toAddress;


### PR DESCRIPTION
Uses default break duration if allowed in settings and if no break was recorded with the timer